### PR TITLE
v 2.2.1

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Finally, Fyrejet is flexible enough to offer you additional abilities to increas
 
 
 
+Starting with Fyrejet 2.2.x, Fyrejet is only compatible with Node.js 12 and higher.
+
+
+
 <a name="footnote1">[1]</a>: 
 
 * `50` tests removed, because they are arguably irrelevant (`test/Route.js` and `test/Router.js`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fyrejet",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Web Framework for node.js that strives to provide (almost) perfect compatibility with Express, while providing better performance, where you need it.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "framework"
   ],
   "engines": {
-    "node": ">=10.x"
+    "node": ">=12.x"
   },
   "author": "Nicholas Schamberg <schamberg.nicholas@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Version 2.2.0 was erroneously released, without making sure it could not be installed on node.js versions lower than 12. V. 2.2.1 fixes that